### PR TITLE
Fallback to disk for loading test resources when bundle does not exist

### DIFF
--- a/Tests/SwiftyChronoTests/ChronoJSXCTestCase.swift
+++ b/Tests/SwiftyChronoTests/ChronoJSXCTestCase.swift
@@ -33,8 +33,14 @@ public class ChronoJSXCTestCase: XCTestCase, ChronoJSTestable {
     }
     
     public func resourcePath(testCasePath: String = #file, name: String, type: String) -> String {
-        let bundle = Bundle(identifier: "io.quire.lib.SwiftyChrono")!
-        return bundle.path(forResource: name, ofType: type)!
+        if let bundle = Bundle(identifier: "io.quire.lib.SwiftyChrono"), let path = bundle.path(forResource: name, ofType: type) {
+            return path
+        } else {
+            // bundle does not exist (expect that if you regenerated SwiftyChrono.xcodeproj with SPM)
+            // assume resource is in the same folder than the test case source file
+            let folder = testCasePath.components(separatedBy: "/").dropLast().joined(separator: "/")
+            return "\(folder)/\(name).\(type)"
+        }
     }
 
     override public func setUp() {

--- a/Tests/SwiftyChronoTests/ChronoJSXCTestCase.swift
+++ b/Tests/SwiftyChronoTests/ChronoJSXCTestCase.swift
@@ -32,6 +32,11 @@ public class ChronoJSXCTestCase: XCTestCase, ChronoJSTestable {
         jsContext.evaluateScript(script)
     }
     
+    public func resourcePath(testCasePath: String = #file, name: String, type: String) -> String {
+        let bundle = Bundle(identifier: "io.quire.lib.SwiftyChrono")!
+        return bundle.path(forResource: name, ofType: type)!
+    }
+
     override public func setUp() {
         super.setUp()
         

--- a/Tests/SwiftyChronoTests/JS/de/TestDE.swift
+++ b/Tests/SwiftyChronoTests/JS/de/TestDE.swift
@@ -25,7 +25,7 @@ class TestDE: ChronoJSXCTestCase {
         Chrono.sixMinutesFixBefore1900 = true
         
         for fileName in files {
-            let js = try! String(contentsOfFile: Bundle(identifier: "io.quire.lib.SwiftyChrono")!.path(forResource: fileName, ofType: "js")!)
+            let js = try! String(contentsOfFile: resourcePath(name: fileName, type: "js"))
             evalJS(js, fileName: fileName)
         }
     }

--- a/Tests/SwiftyChronoTests/JS/en/TestEN.swift
+++ b/Tests/SwiftyChronoTests/JS/en/TestEN.swift
@@ -33,7 +33,7 @@ class TestEN: ChronoJSXCTestCase {
         Chrono.preferredLanguage = .english
         
         for fileName in files {
-            let js = try! String(contentsOfFile: Bundle(identifier: "io.quire.lib.SwiftyChrono")!.path(forResource: fileName, ofType: "js")!)
+            let js = try! String(contentsOfFile: resourcePath(name: fileName, type: "js"))
             evalJS(js, fileName: fileName)
         }
     }

--- a/Tests/SwiftyChronoTests/JS/es/TestES.swift
+++ b/Tests/SwiftyChronoTests/JS/es/TestES.swift
@@ -24,7 +24,7 @@ class TestES: ChronoJSXCTestCase {
         Chrono.sixMinutesFixBefore1900 = true
         
         for fileName in files {
-            let js = try! String(contentsOfFile: Bundle(identifier: "io.quire.lib.SwiftyChrono")!.path(forResource: fileName, ofType: "js")!)
+            let js = try! String(contentsOfFile: resourcePath(name: fileName, type: "js"))
             evalJS(js, fileName: fileName)
         }
     }

--- a/Tests/SwiftyChronoTests/JS/fr/TestFR.swift
+++ b/Tests/SwiftyChronoTests/JS/fr/TestFR.swift
@@ -25,7 +25,7 @@ class TestFR: ChronoJSXCTestCase {
         Chrono.sixMinutesFixBefore1900 = true
         
         for fileName in files {
-            let js = try! String(contentsOfFile: Bundle(identifier: "io.quire.lib.SwiftyChrono")!.path(forResource: fileName, ofType: "js")!)
+            let js = try! String(contentsOfFile: resourcePath(name: fileName, type: "js"))
             evalJS(js, fileName: fileName)
         }
     }

--- a/Tests/SwiftyChronoTests/JS/jp/TestJP.swift
+++ b/Tests/SwiftyChronoTests/JS/jp/TestJP.swift
@@ -19,7 +19,7 @@ class TestJP: ChronoJSXCTestCase {
         Chrono.sixMinutesFixBefore1900 = true
         
         for fileName in files {
-            let js = try! String(contentsOfFile: Bundle(identifier: "io.quire.lib.SwiftyChrono")!.path(forResource: fileName, ofType: "js")!)
+            let js = try! String(contentsOfFile: resourcePath(name: fileName, type: "js"))
             evalJS(js, fileName: fileName)
         }
     }

--- a/Tests/SwiftyChronoTests/JS/zh_hans/TestZHHans.swift
+++ b/Tests/SwiftyChronoTests/JS/zh_hans/TestZHHans.swift
@@ -24,7 +24,7 @@ class TestZHHans: ChronoJSXCTestCase {
 		Chrono.sixMinutesFixBefore1900 = true
 		
 		for fileName in files {
-			let js = try! String(contentsOfFile: Bundle(identifier: "io.quire.lib.SwiftyChrono")!.path(forResource: fileName, ofType: "js")!)
+            let js = try! String(contentsOfFile: resourcePath(name: fileName, type: "js"))
 			evalJS(js, fileName: fileName)
 		}
 	}

--- a/Tests/SwiftyChronoTests/JS/zh_hant/testZHHant.swift
+++ b/Tests/SwiftyChronoTests/JS/zh_hant/testZHHant.swift
@@ -24,7 +24,7 @@ class TestZHHant: ChronoJSXCTestCase {
         Chrono.sixMinutesFixBefore1900 = true
         
         for fileName in files {
-            let js = try! String(contentsOfFile: Bundle(identifier: "io.quire.lib.SwiftyChrono")!.path(forResource: fileName, ofType: "js")!)
+            let js = try! String(contentsOfFile: resourcePath(name: fileName, type: "js"))
             evalJS(js, fileName: fileName)
         }
     }


### PR DESCRIPTION
This branch extracts test resource loading logic to a method.

The new method will load the resource from the lib bundle. If the resource file is not contained in the bundle, it will attempt to load it directly from disk.

That change will allow the tests to pass in scenarios where the lib bundle does not contain the test resources (e.g. if you regenerate the project file using Swift Package Manager, see #13).